### PR TITLE
Fix syntax error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ and add the following:
 
 ```erlang
 {plugins, [
-    {rebar_gleam, {git, "https://github.com/gleam-lang/rebar_gleam"}},
+    {rebar_gleam, {git, "https://github.com/gleam-lang/rebar_gleam"}}
 ]}.
 ```
 


### PR DESCRIPTION
Only necessary to have the comma if there is already data in the list (and this is not the last one).