### PR TITLE
Add stdlib version to rebar.config

### DIFF
--- a/priv/templates/rebar.config
+++ b/priv/templates/rebar.config
@@ -13,5 +13,5 @@
 ]}.
 
 {deps, [
-    gleam_stdlib
+    {gleam_stdlib, "0.3.0"}
 ]}.


### PR DESCRIPTION
This PR adds a version number to the std lib to prevent a stale copy from being used after an upgrade has been performed.

I could not figure out how to test this fork using the actual generator (`rebar3 as global plugins upgrade rebar_gleam` but I have copied and pasted the generated file into a new project and ran a fresh `rebar3 compile` to ensure that it fetches from Hex properly.  

I've also tried `0.3` and `0.3.*` but it seems like neither of these will pull down `0.3.0` from Hex.